### PR TITLE
[SAI] sync SAI changes to campus.

### DIFF
--- a/inc/saifdb.h
+++ b/inc/saifdb.h
@@ -91,6 +91,8 @@ typedef enum _sai_fdb_event_t
 
 /**
  * @brief Attribute Id for FDB entry
+ *
+ * @flags ranges
  */
 typedef enum _sai_fdb_entry_attr_t
 {
@@ -135,7 +137,7 @@ typedef enum _sai_fdb_entry_attr_t
      * The port id is only effective when the packet action is one of the
      * following: FORWARD, COPY, LOG, TRANSIT
      *
-     * When it is SAI_NULL_OBJECT_ID, then packet will be dropped.
+     * When it is SAI_NULL_OBJECT_ID and SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID_LIST is empty, then packet will be dropped.
      *
      * @type sai_object_id_t
      * @flags CREATE_AND_SET
@@ -197,6 +199,21 @@ typedef enum _sai_fdb_entry_attr_t
 
     /** Start of custom range base value */
     SAI_FDB_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /**
+     * @brief FDB entry bridge port id list
+     *
+     * The port id is only effective when the packet action is one of the
+     * following: FORWARD, COPY, LOG, TRANSIT
+     *
+     * When it is empty and SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID is SAI_NULL_OBJECT_ID, then packet will be dropped.
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_BRIDGE_PORT
+     * @default empty
+     */
+    SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID_LIST = 0x10000001,
 
     /** End of custom range */
     SAI_FDB_ENTRY_ATTR_CUSTOM_RANGE_END

--- a/inc/saiipmc.h
+++ b/inc/saiipmc.h
@@ -77,6 +77,8 @@ typedef struct _sai_ipmc_entry_t
 
 /**
  * @brief Attribute Id for IPMC entry
+ *
+ * @flags ranges
  */
 typedef enum _sai_ipmc_entry_attr_t
 {
@@ -139,6 +141,15 @@ typedef enum _sai_ipmc_entry_attr_t
 
     /** Custom range base value */
     SAI_IPMC_ENTRY_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /**
+     * @brief Query IPMC entry active status
+     *
+     * @type bool
+     * @flags READ_ONLY
+     * @isresourcetype true
+     */
+    SAI_IPMC_ENTRY_ATTR_CUSTOM_ACTIVE_STATUS,
 
     /** Custom range base end value */
     SAI_IPMC_ENTRY_ATTR_CUSTOM_RANGE_END

--- a/inc/saiisolationgroup.h
+++ b/inc/saiisolationgroup.h
@@ -81,6 +81,24 @@ typedef enum _sai_isolation_group_attr_t
     /** Custom range base value */
     SAI_ISOLATION_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
 
+    /**
+     * @brief Source IP Address, valid when type is SAI_ISOLATION_GROUP_TYPE_CUSTOM_FLOODING_FLOW
+     *
+     * @type sai_ip_address_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_ISOLATION_GROUP_ATTR_CUSTOM_FLOODING_FLOW_FILTER_OUTER_SRC_IP,
+
+    /**
+     * @brief Source IP Address mask, valid when type is SAI_ISOLATION_GROUP_TYPE_CUSTOM_FLOODING_FLOW
+     *
+     * @type sai_ip_address_t
+     * @flags CREATE_AND_SET
+     * @default empty
+     */
+    SAI_ISOLATION_GROUP_ATTR_CUSTOM_FLOODING_FLOW_FILTER_OUTER_SRC_IP_MASK,
+
     /** End of custom range base */
     SAI_ISOLATION_GROUP_ATTR_CUSTOM_RANGE_END
 

--- a/inc/saiport.h
+++ b/inc/saiport.h
@@ -3129,6 +3129,15 @@ typedef enum _sai_port_attr_t
      */
     SAI_PORT_ATTR_CUSTOM_L2PT_CDP_PACKET_ENABLE,
 
+    /**
+     * @brief Enable/Disable function
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_PORT_ATTR_CUSTOM_DOT1Q_TUNNEL,
+
     /** End of custom range base */
     SAI_PORT_ATTR_CUSTOM_RANGE_END,
 

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -3681,6 +3681,14 @@ typedef enum _sai_switch_attr_t
      */
     SAI_SWITCH_ATTR_CUSTOM_FDB_SECURE_BREACH_EVENT_NOTIFY,
 
+    /**
+     * @brief Get specification of MAC to me table size
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_CUSTOM_MAC2ME_TABLE_SIZE,
+
     /** End of custom range base */
     SAI_SWITCH_ATTR_CUSTOM_RANGE_END,
 

--- a/inc/saitunnel.h
+++ b/inc/saitunnel.h
@@ -579,7 +579,6 @@ typedef enum _sai_tunnel_attr_t
      * @type sai_ip_address_t
      * @flags CREATE_ONLY
      * @default 0.0.0.0
-     * @validonly SAI_TUNNEL_ATTR_PEER_MODE == SAI_TUNNEL_PEER_MODE_P2P
      */
     SAI_TUNNEL_ATTR_ENCAP_DST_IP,
 

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -584,6 +584,27 @@ typedef enum _sai_vlan_attr_t
      */
     SAI_VLAN_ATTR_CUSTOM_REMOVE_PORTS,
 
+    /**
+     * @brief Set ARP request action trap
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_VLAN_ATTR_CUSTOM_TRAP_ARP,
+
+    /**
+     * @brief Counter enable or disable control for VLAN
+     *
+     * Counter enable control for VLAN. Default is
+     * disabled
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_VLAN_ATTR_CUSTOM_COUNTER_ENABLE,
+
     /** End of custom range base */
     SAI_VLAN_ATTR_CUSTOM_RANGE_END
 

--- a/support_sai_attribute_list/saifdb.md
+++ b/support_sai_attribute_list/saifdb.md
@@ -18,6 +18,7 @@
 |  | SAI_FDB_ENTRY_ATTR_ENDPOINT_IP |  | no |  |
 |  | SAI_FDB_ENTRY_ATTR_COUNTER_ID |  | no |  |
 |  | SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE |  | no |  |
+|  | SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID_LIST |  | yes | yes |
 | remove_fdb_entry |  |  | yes |  |
 | set_fdb_entry_attribute | SAI_FDB_ENTRY_ATTR_TYPE | SAI_FDB_ENTRY_TYPE_DYNAMIC | yes |  |
 |  |  | SAI_FDB_ENTRY_TYPE_STATIC | yes |  |
@@ -37,6 +38,7 @@
 |  | SAI_FDB_ENTRY_ATTR_ENDPOINT_IP |  | no |  |
 |  | SAI_FDB_ENTRY_ATTR_COUNTER_ID |  | no |  |
 |  | SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE |  | no |  |
+|  | SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID_LIST |  | yes | yes |
 | get_fdb_entry_attribute | SAI_FDB_ENTRY_ATTR_TYPE |  | yes |  |
 |  | SAI_FDB_ENTRY_ATTR_PACKET_ACTION |  | yes |  |
 |  | SAI_FDB_ENTRY_ATTR_USER_TRAP_ID |  | no |  |
@@ -45,6 +47,7 @@
 |  | SAI_FDB_ENTRY_ATTR_ENDPOINT_IP |  | no |  |
 |  | SAI_FDB_ENTRY_ATTR_COUNTER_ID |  | no |  |
 |  | SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE |  | no |  |
+|  | SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID_LIST |  | yes | yes |
 | flush_fdb_entries | SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID |  | yes |  |
 |  | SAI_FDB_FLUSH_ATTR_BV_ID |  | yes |  |
 |  | SAI_FDB_FLUSH_ATTR_ENTRY_TYPE | SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC | yes |  |

--- a/support_sai_attribute_list/saiipmc.md
+++ b/support_sai_attribute_list/saiipmc.md
@@ -31,4 +31,5 @@
 |  | SAI_IPMC_ENTRY_ATTR_OUTPUT_GROUP_ID |  | yes |  |
 |  | SAI_IPMC_ENTRY_ATTR_RPF_GROUP_ID |  | yes |  |
 |  | SAI_IPMC_ENTRY_ATTR_COUNTER_ID |  | no |  |
+|  | SAI_IPMC_ENTRY_ATTR_CUSTOM_ACTIVE_STATUS |  | yes |  yes |
 

--- a/support_sai_attribute_list/saiisolationgroup.md
+++ b/support_sai_attribute_list/saiisolationgroup.md
@@ -3,6 +3,8 @@
 | create_isolation_group | SAI_ISOLATION_GROUP_ATTR_TYPE | SAI_ISOLATION_GROUP_TYPE_PORT | no |  |
 |  |  | SAI_ISOLATION_GROUP_TYPE_BRIDGE_PORT | yes |  |
 |  | SAI_ISOLATION_GROUP_ATTR_ISOLATION_MEMBER_LIST |  | yes |  |
+|  | SAI_ISOLATION_GROUP_ATTR_CUSTOM_FLOODING_FLOW_FILTER_OUTER_SRC_IP |  | yes | yes |
+|  | SAI_ISOLATION_GROUP_ATTR_CUSTOM_FLOODING_FLOW_FILTER_OUTER_SRC_IP_MASK |  | yes | yes |
 | remove_isolation_group |  |  | yes |  |
 | set_isolation_group_attribute |  |  | no |  |
 | get_isolation_group_attribute | SAI_ISOLATION_GROUP_ATTR_TYPE |  | yes |  |

--- a/support_sai_attribute_list/saiport.md
+++ b/support_sai_attribute_list/saiport.md
@@ -389,6 +389,7 @@
 |  | SAI_PORT_ATTR_CUSTOM_L2PT_LACP_PACKET_ENABLE |  | yes | yes |
 |  | SAI_PORT_ATTR_CUSTOM_L2PT_PVSTP_PACKET_ENABLE |  | yes | yes |
 |  | SAI_PORT_ATTR_CUSTOM_L2PT_CDP_PACKET_ENABLE |  | yes | yes |
+|  | SAI_PORT_ATTR_CUSTOM_DOT1Q_TUNNEL |  | yes | yes |
 | remove_port |  |  | yes |  |
 | set_port_attribute | SAI_PORT_ATTR_AUTO_NEG_MODE |  | yes |  |
 |  | SAI_PORT_ATTR_ADMIN_STATE |  | yes |  |
@@ -1003,6 +1004,7 @@
 |  | SAI_PORT_ATTR_CUSTOM_L2PT_LACP_PACKET_ENABLE |  | yes | yes |
 |  | SAI_PORT_ATTR_CUSTOM_L2PT_PVSTP_PACKET_ENABLE |  | yes | yes |
 |  | SAI_PORT_ATTR_CUSTOM_L2PT_CDP_PACKET_ENABLE |  | yes | yes |
+|  | SAI_PORT_ATTR_CUSTOM_DOT1Q_TUNNEL |  | yes | yes |
 | get_port_stats | SAI_PORT_STAT_IF_IN_OCTETS |  | no |  |
 |  | SAI_PORT_STAT_IF_IN_UCAST_PKTS |  | yes |  |
 |  | SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS |  | yes |  |
@@ -1200,6 +1202,7 @@
 |  | SAI_PORT_STAT_ETHER_OUT_PKTS_1519_TO_2500_OCTETS |  | no |  |
 |  | SAI_PORT_STAT_ETHER_OUT_PKTS_2501_TO_9000_OCTETS |  | no |  |
 |  | SAI_PORT_STAT_ETHER_OUT_PKTS_9001_TO_16383_OCTETS |  | no |  |
+|  | SAI_PORT_ATTR_CUSTOM_DOT1Q_TUNNEL |  | yes | yes |
 | clear_port_stats |  |  | no |  |
 | clear_port_all_stats |  |  | yes |  |
 | create_port_pool |  |  | no |  |

--- a/support_sai_attribute_list/saiswitch.md
+++ b/support_sai_attribute_list/saiswitch.md
@@ -668,6 +668,7 @@
 |  | SAI_SWITCH_ATTR_CUSTOM_SNP6_ENTRY      |  | yes | yes |
 |  | SAI_SWITCH_ATTR_CUSTOM_SELECTED_SYNCE_PORT |  | yes | yes |
 |  | SAI_SWITCH_ATTR_CUSTOM_FDB_SECURE_BREACH_EVENT_NOTIFY |  | yes | yes |
+|  | SAI_SWITCH_ATTR_CUSTOM_MAC2ME_TABLE_SIZE |  | yes | yes |
 | get_switch_stats |  |  | no |  |
 | get_switch_stats_ext |  |  | no |  |
 | clear_switch_stats |  |  | no |  |

--- a/support_sai_attribute_list/saivlan.md
+++ b/support_sai_attribute_list/saivlan.md
@@ -56,6 +56,8 @@
 |  | SAI_VLAN_ATTR_CUSTOM_MLD_SNOOPING_ENABLE |  | yes | yes |
 |  | SAI_VLAN_ATTR_CUSTOM_CREATE_PORTS |  | yes | yes |
 |  | SAI_VLAN_ATTR_CUSTOM_REMOVE_PORTS |  | yes | yes |
+|  | SAI_VLAN_ATTR_CUSTOM_TRAP_ARP     |  | yes | yes |
+|  | SAI_VLAN_ATTR_CUSTOM_COUNTER_ENABLE |  | yes | yes |
 | remove_vlan |  |  | yes |  |
 | set_vlan_attribute | SAI_VLAN_ATTR_MAX_LEARNED_ADDRESSES |  | yes |  |
 |  | SAI_VLAN_ATTR_STP_INSTANCE |  | yes |  |
@@ -112,6 +114,8 @@
 |  | SAI_VLAN_ATTR_CUSTOM_MLD_SNOOPING_ENABLE |  | yes | yes |
 |  | SAI_VLAN_ATTR_CUSTOM_CREATE_PORTS |  | yes | yes |
 |  | SAI_VLAN_ATTR_CUSTOM_REMOVE_PORTS |  | yes | yes |
+|  | SAI_VLAN_ATTR_CUSTOM_TRAP_ARP     |  | yes | yes |
+|  | SAI_VLAN_ATTR_CUSTOM_COUNTER_ENABLE |  | yes | yes |
 | get_vlan_attribute | SAI_VLAN_ATTR_VLAN_ID |  | yes |  |
 |  | SAI_VLAN_ATTR_MEMBER_LIST |  | yes |  |
 |  | SAI_VLAN_ATTR_MAX_LEARNED_ADDRESSES |  | yes |  |
@@ -151,6 +155,8 @@
 |  | SAI_VLAN_ATTR_CUSTOM_MLD_SNOOPING_ENABLE |  | yes | yes |
 |  | SAI_VLAN_ATTR_CUSTOM_CREATE_PORTS |  | yes | yes |
 |  | SAI_VLAN_ATTR_CUSTOM_REMOVE_PORTS |  | yes | yes |
+|  | SAI_VLAN_ATTR_CUSTOM_TRAP_ARP     |  | yes | yes |
+|  | SAI_VLAN_ATTR_CUSTOM_COUNTER_ENABLE |  | yes | yes |
 | create_vlan_member | SAI_VLAN_MEMBER_ATTR_VLAN_ID |  | yes |  |
 |  | SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID |  | yes |  |
 |  | SAI_VLAN_MEMBER_ATTR_VLAN_TAGGING_MODE | SAI_VLAN_TAGGING_MODE_UNTAGGED | yes |  |


### PR DESCRIPTION
    [ARP] Support Trap ARP on vlan-level.

    [VXLAN] Support xconnect feature.

    [VXLAN] Support multicast vxlan for BUM.

    [EVPN-MH] Support SAI_FDB_ENTRY_ATTR_CUSTOM_BRIDGE_PORT_ID_LIST.

    [EVPN-MH] support split horizon filter and DF.

    [ipmc] add attribute SAI_IPMC_ENTRY_ATTR_CUSTOM_ACTIVE_STATUS

    [VLAN] support vlan counters.

    [ROUTE] Support to get router mac table size.

reviewer: Wang Lin