### PR TITLE
[QinQ] Support basic qinq for lag & popping outer vlan.(CX61-2549). r…

### DIFF
--- a/inc/sailag.h
+++ b/inc/sailag.h
@@ -273,6 +273,15 @@ typedef enum _sai_lag_attr_t
      */
     SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_GROUP,
 
+    /**
+     * @brief Basic enable
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_LAG_ATTR_CUSTOM_BASIC_QINQ_ENABLE,
+
     /** End of custom range base */
     SAI_LAG_ATTR_CUSTOM_RANGE_END
 

--- a/inc/saivlan.h
+++ b/inc/saivlan.h
@@ -47,6 +47,8 @@ typedef enum _sai_vlan_tagging_mode_t
 
     SAI_VLAN_TAGGING_MODE_TAGGED,
 
+    SAI_VLAN_TAGGING_MODE_CUSTOMER_TAGGED,
+
     SAI_VLAN_TAGGING_MODE_PRIORITY_TAGGED
 
 } sai_vlan_tagging_mode_t;

--- a/support_sai_attribute_list/sailag.md
+++ b/support_sai_attribute_list/sailag.md
@@ -22,6 +22,7 @@
 |  | SAI_LAG_ATTR_CUSTOM_ISOLATION_GROUP |  | no | yes |
 |  | SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_PRIORITY |  | no | yes |
 |  | SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_GROUP |  | no | yes |
+|  | SAI_LAG_ATTR_CUSTOM_BASIC_QINQ_ENABLE |  | no | yes |
 | remove_lag |  |  | yes |  |
 | set_lag_attribute | SAI_LAG_ATTR_INGRESS_ACL |  | yes |  |
 |  | SAI_LAG_ATTR_EGRESS_ACL |  | yes |  |
@@ -35,6 +36,7 @@
 |  | SAI_LAG_ATTR_CUSTOM_ISOLATION_GROUP |  | no | yes |
 |  | SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_PRIORITY |  | no | yes |
 |  | SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_GROUP |  | no | yes |
+|  | SAI_LAG_ATTR_CUSTOM_BASIC_QINQ_ENABLE |  | no | yes |
 | get_lag_attribute | SAI_LAG_ATTR_PORT_LIST |  | yes |  |
 |  | SAI_LAG_ATTR_INGRESS_ACL |  | yes |  |
 |  | SAI_LAG_ATTR_EGRESS_ACL |  | yes |  |
@@ -52,6 +54,7 @@
 |  | SAI_LAG_ATTR_CUSTOM_ISOLATION_GROUP |  | no | yes |
 |  | SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_PRIORITY |  | no | yes |
 |  | SAI_LAG_ATTR_CUSTOM_FDB_LEARNING_GROUP |  | no | yes |
+|  | SAI_LAG_ATTR_CUSTOM_BASIC_QINQ_ENABLE |  | no | yes |
 | create_lag_member | SAI_LAG_MEMBER_ATTR_LAG_ID |  | yes |  |
 |  | SAI_LAG_MEMBER_ATTR_PORT_ID |  | yes |  |
 |  | SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE |  | yes |  |


### PR DESCRIPTION
…eviwer:wanglin,zhouyongsheng


1. lag support qinq
2. lag/port support pop vlan on egress direction

sonic-cli like below：
sonic(config-lagif-1)# show this
interface link-aggregation 1
 mode static
 qinq enable
 mtu 9216
 switchport trunk vlan 10
 switchport untagged vlan 10
 commit
exit
!